### PR TITLE
op3: Use correct ACDB ids

### DIFF
--- a/audio/audio_platform_info.xml
+++ b/audio/audio_platform_info.xml
@@ -29,12 +29,6 @@
         <device name="SND_DEVICE_OUT_SPEAKER" acdb_id="15" />
         <device name="SND_DEVICE_OUT_VOICE_SPEAKER" acdb_id="15" />
         <device name="SND_DEVICE_OUT_SPEAKER_PROTECTED" acdb_id="124" />
-        <device name="SND_DEVICE_OUT_VOICE_HEADPHONES" acdb_id="26" />
-        <device name="SND_DEVICE_IN_HANDSET_DMIC_AEC_NS" acdb_id="41" />
-        <device name="SND_DEVICE_IN_SPEAKER_DMIC_AEC_NS" acdb_id="43" />
-        <device name="SND_DEVICE_IN_HEADSET_MIC_FLUENCE" acdb_id="16" />
-        <device name="SND_DEVICE_IN_VOICE_HEADSET_MIC" acdb_id="16" />
-        <device name="SND_DEVICE_IN_HEADSET_MIC" acdb_id="8" />
     </acdb_ids>
     <bit_width_configs>
         <device name="SND_DEVICE_OUT_SPEAKER" bit_width="24"/>


### PR DESCRIPTION
 * https://github.com/OnePlusOSS/android_hardware_qcom_audio/commit/e55a3dae028c80b9c2b24e8c078176e137584a00

Change-Id: I85367fb528d62b1ab7b992c80b8c0d499970550f